### PR TITLE
[UPDATE] Modify JPA method name

### DIFF
--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/repositories/OwnerRepository.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/repositories/OwnerRepository.java
@@ -12,5 +12,5 @@ public interface OwnerRepository extends CrudRepository<Owner, Long> {
 
     Owner findByLastName(String lastName);
 
-    List<Owner> findAllByLastNameLike(String lastName);
+    List<Owner> findAllByLastNameContaining(String lastName);
 }

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/services/OwnerService.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/services/OwnerService.java
@@ -12,5 +12,5 @@ public interface OwnerService extends CrudService<Owner, Long> {
 
     Owner findByLastName(String lastName);
 
-    List<Owner> findAllByLastNameLike(String lastName);
+    List<Owner> findAllByLastNameContaining(String lastName);
  }

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/services/map/OwnerMapService.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/services/map/OwnerMapService.java
@@ -84,7 +84,7 @@ public class OwnerMapService extends AbstractMapService<Owner, Long> implements 
     }
 
     @Override
-    public List<Owner> findAllByLastNameLike(String lastName) {
+    public List<Owner> findAllByLastNameContaining(String lastName) {
 
         //todo - impl
         return null;

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/services/springdatajpa/OwnerSDJpaService.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/services/springdatajpa/OwnerSDJpaService.java
@@ -36,8 +36,8 @@ public class OwnerSDJpaService implements OwnerService {
     }
 
     @Override
-    public List<Owner> findAllByLastNameLike(String lastName) {
-        return ownerRepository.findAllByLastNameLike(lastName);
+    public List<Owner> findAllByLastNameContaining(String lastName) {
+        return ownerRepository.findAllByLastNameContaining(lastName);
     }
 
     @Override

--- a/pet-clinic-web/src/main/java/guru/springframework/sfgpetclinic/controllers/OwnerController.java
+++ b/pet-clinic-web/src/main/java/guru/springframework/sfgpetclinic/controllers/OwnerController.java
@@ -46,7 +46,7 @@ public class OwnerController {
         }
 
         // find owners by last name
-        List<Owner> results = ownerService.findAllByLastNameLike("%"+ owner.getLastName() + "%");
+        List<Owner> results = ownerService.findAllByLastNameContaining(owner.getLastName());
 
         if (results.isEmpty()) {
             // no owners found

--- a/pet-clinic-web/src/test/java/guru/springframework/sfgpetclinic/controllers/OwnerControllerTest.java
+++ b/pet-clinic-web/src/test/java/guru/springframework/sfgpetclinic/controllers/OwnerControllerTest.java
@@ -60,7 +60,7 @@ class OwnerControllerTest {
 
     @Test
     void processFindFormReturnMany() throws Exception {
-        when(ownerService.findAllByLastNameLike(anyString()))
+        when(ownerService.findAllByLastNameContaining(anyString()))
                 .thenReturn(Arrays.asList(Owner.builder().id(1l).build(),
                         Owner.builder().id(2l).build()));
 
@@ -72,7 +72,7 @@ class OwnerControllerTest {
 
     @Test
     void processFindFormReturnOne() throws Exception {
-        when(ownerService.findAllByLastNameLike(anyString())).thenReturn(Arrays.asList(Owner.builder().id(1l).build()));
+        when(ownerService.findAllByLastNameContaining(anyString())).thenReturn(Arrays.asList(Owner.builder().id(1l).build()));
 
         mockMvc.perform(get("/owners"))
                 .andExpect(status().is3xxRedirection())


### PR DESCRIPTION
I am studying well by listening to your lecture.

Today I listened to your lecture (Section 11, Lecture 223. Fix Find Owner Like). In this lecture, you fixed 
```java
ownerService.findAllByLastNameLike(owner.getLastName());
```
to
```java
ownerService.findAllByLastNameLike("%"+ owner.getLastName() + "%")
```

I searched for [JPA method keyword](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.query-methods.query-creation), and I found `Containing` keyword.

So I fixed this code like this, and it works fine! 
```java
ownerService.findAllByLastNameContaining(owner.getLastName());
```

Please check this!

Your lecture is very good for me! 
Thank you very much!