### PR TITLE
Adding missing unit test for map services.

### DIFF
--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Owner.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Owner.java
@@ -1,13 +1,16 @@
 package guru.springframework.sfgpetclinic.model;
 
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Created by jt on 7/13/18.
@@ -17,6 +20,7 @@ import java.util.Set;
 @NoArgsConstructor
 @Entity
 @Table(name = "owners")
+@SuppressWarnings("JpaDataSourceORMInspection")
 public class Owner extends Person {
 
     @Builder

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Pet.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Pet.java
@@ -1,12 +1,21 @@
 package guru.springframework.sfgpetclinic.model;
 
-import lombok.*;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 /**
  * Created by jt on 7/13/18.
@@ -17,6 +26,7 @@ import java.util.Set;
 @AllArgsConstructor
 @Entity
 @Table(name = "pets")
+@SuppressWarnings("JpaDataSourceORMInspection")
 public class Pet extends BaseEntity{
 
     @Builder

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/PetType.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/PetType.java
@@ -1,10 +1,13 @@
 package guru.springframework.sfgpetclinic.model;
 
-import lombok.*;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Created by jt on 7/13/18.
@@ -16,6 +19,7 @@ import javax.persistence.Table;
 @AllArgsConstructor
 @Entity
 @Table(name = "types")
+@SuppressWarnings("JpaDataSourceORMInspection")
 public class PetType extends BaseEntity {
 
     @Builder

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Speciality.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Speciality.java
@@ -1,10 +1,13 @@
 package guru.springframework.sfgpetclinic.model;
 
-import lombok.*;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Created by jt on 7/29/18.
@@ -13,10 +16,16 @@ import javax.persistence.Table;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "specialties")
+@SuppressWarnings("JpaDataSourceORMInspection")
 public class Speciality extends BaseEntity {
+
+    @Builder
+    public Speciality(Long id, String description) {
+        super(id);
+        this.description = description;
+    }
 
     @Column(name = "description")
     private String description;

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Vet.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Vet.java
@@ -1,10 +1,18 @@
 package guru.springframework.sfgpetclinic.model;
 
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Created by jt on 7/13/18.
@@ -13,10 +21,22 @@ import java.util.Set;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "vets")
+@SuppressWarnings("JpaDataSourceORMInspection")
 public class Vet extends Person {
+
+    @Builder
+    public Vet(final Long id,
+               final String firstName,
+               final String lastName,
+               final Set<Speciality> specialities) {
+        super(id, firstName, lastName);
+
+        if(specialities != null) {
+            this.specialities = specialities;
+        }
+    }
 
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "vet_specialties", joinColumns = @JoinColumn(name = "vet_id"),

--- a/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Visit.java
+++ b/pet-clinic-data/src/main/java/guru/springframework/sfgpetclinic/model/Visit.java
@@ -1,9 +1,16 @@
 package guru.springframework.sfgpetclinic.model;
 
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Created by jt on 7/29/18.
@@ -12,10 +19,18 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 @Entity
 @Table(name = "visits")
+@SuppressWarnings("JpaDataSourceORMInspection")
 public class Visit extends BaseEntity {
+
+    @Builder
+    public Visit(Long id, LocalDate date, String description, Pet pet) {
+        super(id);
+        this.date = date;
+        this.description = description;
+        this.pet = pet;
+    }
 
     @Column(name = "date")
     private LocalDate date;

--- a/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/OwnerMapServiceTest.java
+++ b/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/OwnerMapServiceTest.java
@@ -4,86 +4,172 @@ import guru.springframework.sfgpetclinic.model.Owner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+/**
+ * @author jt
+ * @author <a href="https://www.github.com/yonatankarp>Yonatan Karp-Rudin</a>
+ */
 class OwnerMapServiceTest {
 
-    OwnerMapService ownerMapService;
+    private static final Long OWNER_ID = 1L;
+    private static final String LAST_NAME = "Smith";
 
-    final Long ownerId = 1L;
-    final String lastName = "Smith";
+    private OwnerMapService ownerMapService;
 
     @BeforeEach
     void setUp() {
         ownerMapService = new OwnerMapService(new PetTypeMapService(), new PetMapService());
 
-        ownerMapService.save(Owner.builder().id(ownerId).lastName(lastName).build());
+        ownerMapService.save(Owner.builder().id(OWNER_ID).lastName(LAST_NAME).build());
     }
 
     @Test
     void findAll() {
-        Set<Owner> ownerSet = ownerMapService.findAll();
+        final var ownerSet = ownerMapService.findAll();
 
         assertEquals(1, ownerSet.size());
     }
 
     @Test
-    void findById() {
-        Owner owner = ownerMapService.findById(ownerId);
+    void findByExistingId() {
+        final var owner = ownerMapService.findById(OWNER_ID);
 
-        assertEquals(ownerId, owner.getId());
+        assertEquals(OWNER_ID, owner.getId());
+    }
+
+    @Test
+    void findByIdNotExistingId() {
+
+        final var owner = ownerMapService.findById(5L);
+
+        assertNull(owner);
+    }
+
+    @Test
+    void findByIdNullId() {
+
+        final var owner = ownerMapService.findById(null);
+
+        assertNull(owner);
     }
 
     @Test
     void saveExistingId() {
-        Long id = 2L;
+        final Long id = 2L;
 
-        Owner owner2 = Owner.builder().id(id).build();
+        final var owner2 = Owner.builder().id(id).build();
 
-        Owner savedOwner = ownerMapService.save(owner2);
+        final var savedOwner = ownerMapService.save(owner2);
 
         assertEquals(id, savedOwner.getId());
+    }
 
+    @Test
+    void saveDuplicateId() {
+
+        final Long id = 1L;
+
+        final var owner2 = Owner.builder().id(id).build();
+
+        final var savedOwner = ownerMapService.save(owner2);
+
+        assertEquals(id, savedOwner.getId());
+        assertEquals(1, ownerMapService.findAll().size());
     }
 
     @Test
     void saveNoId() {
 
-        Owner savedOwner = ownerMapService.save(Owner.builder().build());
+        final var savedOwner = ownerMapService.save(Owner.builder().build());
 
         assertNotNull(savedOwner);
         assertNotNull(savedOwner.getId());
     }
 
     @Test
-    void delete() {
-        ownerMapService.delete(ownerMapService.findById(ownerId));
+    void deleteOwner() {
+        ownerMapService.delete(ownerMapService.findById(OWNER_ID));
 
         assertEquals(0, ownerMapService.findAll().size());
     }
 
     @Test
-    void deleteById() {
-        ownerMapService.deleteById(ownerId);
+    void deleteWithWrongId() {
+
+        final var owner = Owner.builder().id(5L).build();
+
+        ownerMapService.delete(owner);
+
+        assertEquals(1, ownerMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithNullId() {
+
+        final var owner = Owner.builder().build();
+
+        ownerMapService.delete(owner);
+
+        assertEquals(1, ownerMapService.findAll().size());
+    }
+
+    @Test
+    void deleteNull() {
+
+        ownerMapService.delete(null);
+
+        assertEquals(1, ownerMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdCorrectId() {
+        ownerMapService.deleteById(OWNER_ID);
 
         assertEquals(0, ownerMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdWrongId() {
+
+        ownerMapService.deleteById(5L);
+
+        assertEquals(1, ownerMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdNullId() {
+
+        ownerMapService.deleteById(null);
+
+        assertEquals(1, ownerMapService.findAll().size());
     }
 
     @Test
     void findByLastName() {
-        Owner smith = ownerMapService.findByLastName(lastName);
+        final var smith = ownerMapService.findByLastName(LAST_NAME);
 
         assertNotNull(smith);
 
-        assertEquals(ownerId, smith.getId());
+        assertEquals(OWNER_ID, smith.getId());
+        assertEquals(LAST_NAME, smith.getLastName());
+    }
 
+    @Test
+    void findByLastNameLowerCase() {
+        final var smith = ownerMapService.findByLastName(LAST_NAME.toLowerCase());
+
+        assertNotNull(smith);
+
+        assertEquals(OWNER_ID, smith.getId());
+        assertEquals(LAST_NAME, smith.getLastName());
     }
 
     @Test
     void findByLastNameNotFound() {
-        Owner smith = ownerMapService.findByLastName("foo");
+        final var smith = ownerMapService.findByLastName("foo");
 
         assertNull(smith);
     }

--- a/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/PetMapServiceTest.java
+++ b/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/PetMapServiceTest.java
@@ -4,34 +4,34 @@ import guru.springframework.sfgpetclinic.model.Pet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * JUnit5 test.
  *
  * @author <a href="mailto:k.czechowski83@gmail.com">Krzysztof Czechowski</a>
+ * @author <a href="https://www.github.com/yonatankarp>Yonatan Karp-Rudin</a>
  */
 
 class PetMapServiceTest {
 
     private PetMapService petMapService;
 
-    private final Long petId = 1L;
+    private static final Long PET_ID = 1L;
 
     @BeforeEach
     void setUp() {
-
         petMapService = new PetMapService();
 
-        petMapService.save(Pet.builder().id(petId).build());
+        petMapService.save(Pet.builder().id(PET_ID).build());
     }
 
     @Test
     void findAll() {
 
-        Set<Pet> petSet = petMapService.findAll();
+        final var petSet = petMapService.findAll();
 
         assertEquals(1, petSet.size());
     }
@@ -39,15 +39,15 @@ class PetMapServiceTest {
     @Test
     void findByIdExistingId() {
 
-        Pet pet = petMapService.findById(petId);
+        final var pet = petMapService.findById(PET_ID);
 
-        assertEquals(petId, pet.getId());
+        assertEquals(PET_ID, pet.getId());
     }
 
     @Test
     void findByIdNotExistingId() {
 
-        Pet pet = petMapService.findById(5L);
+        final var pet = petMapService.findById(5L);
 
         assertNull(pet);
     }
@@ -55,7 +55,7 @@ class PetMapServiceTest {
     @Test
     void findByIdNullId() {
 
-        Pet pet = petMapService.findById(null);
+        final var pet = petMapService.findById(null);
 
         assertNull(pet);
     }
@@ -63,11 +63,11 @@ class PetMapServiceTest {
     @Test
     void saveExistingId() {
 
-        Long id = 2L;
+        final Long id = 2L;
 
-        Pet pet2 = Pet.builder().id(id).build();
+        final var pet2 = Pet.builder().id(id).build();
 
-        Pet savedPet = petMapService.save(pet2);
+        final var savedPet = petMapService.save(pet2);
 
         assertEquals(id, savedPet.getId());
     }
@@ -75,11 +75,11 @@ class PetMapServiceTest {
     @Test
     void saveDuplicateId() {
 
-        Long id = 1L;
+        final Long id = 1L;
 
-        Pet pet2 = Pet.builder().id(id).build();
+        final var pet2 = Pet.builder().id(id).build();
 
-        Pet savedPet = petMapService.save(pet2);
+        final var savedPet = petMapService.save(pet2);
 
         assertEquals(id, savedPet.getId());
         assertEquals(1, petMapService.findAll().size());
@@ -88,7 +88,7 @@ class PetMapServiceTest {
     @Test
     void saveNoId() {
 
-        Pet savedPet = petMapService.save(Pet.builder().build());
+        final var savedPet = petMapService.save(Pet.builder().build());
 
         assertNotNull(savedPet);
         assertNotNull(savedPet.getId());
@@ -98,7 +98,7 @@ class PetMapServiceTest {
     @Test
     void deletePet() {
 
-        petMapService.delete(petMapService.findById(petId));
+        petMapService.delete(petMapService.findById(PET_ID));
 
         assertEquals(0, petMapService.findAll().size());
 
@@ -107,7 +107,7 @@ class PetMapServiceTest {
     @Test
     void deleteWithWrongId() {
 
-        Pet pet = Pet.builder().id(5L).build();
+        final var pet = Pet.builder().id(5L).build();
 
         petMapService.delete(pet);
 
@@ -117,7 +117,7 @@ class PetMapServiceTest {
     @Test
     void deleteWithNullId() {
 
-        Pet pet = Pet.builder().build();
+        final var pet = Pet.builder().build();
 
         petMapService.delete(pet);
 
@@ -136,7 +136,7 @@ class PetMapServiceTest {
     @Test
     void deleteByIdCorrectId() {
 
-        petMapService.deleteById(petId);
+        petMapService.deleteById(PET_ID);
 
         assertEquals(0, petMapService.findAll().size());
     }

--- a/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/PetTypeMapServiceTest.java
+++ b/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/PetTypeMapServiceTest.java
@@ -1,0 +1,145 @@
+package guru.springframework.sfgpetclinic.services.map;
+
+import guru.springframework.sfgpetclinic.model.PetType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author <a href="https://www.github.com/yonatankarp>Yonatan Karp-Rudin</a>
+ */
+class PetTypeMapServiceTest {
+
+    private static final Long PET_TYPE_ID = 1L;
+
+    private PetTypeMapService petTypeMapService;
+
+    @BeforeEach
+    void setUp() {
+        petTypeMapService = new PetTypeMapService();
+
+        petTypeMapService.save(PetType.builder().id(PET_TYPE_ID).build());
+    }
+
+    @Test
+    void findAll() {
+        final var petTypes = petTypeMapService.findAll();
+        assertEquals(1, petTypes.size());
+    }
+
+    @Test
+    void findByExistingId() {
+        final var petType = petTypeMapService.findById(PET_TYPE_ID);
+        assertEquals(PET_TYPE_ID, petType.getId());
+    }
+
+    @Test
+    void findByNotExistingId() {
+        final var petType = petTypeMapService.findById(5L);
+        assertNull(petType);
+    }
+
+    @Test
+    void findByIdNullId() {
+        final var petType = petTypeMapService.findById(null);
+        assertNull(petType);
+    }
+
+    @Test
+    void saveExistingId() {
+        final Long id = 2L;
+
+        final var petType2 = PetType.builder().id(id).build();
+
+        final var savedPet = petTypeMapService.save(petType2);
+
+        assertEquals(id, savedPet.getId());
+    }
+
+    @Test
+    void saveDuplicateId() {
+
+        final Long id = 1L;
+
+        final var petType2 = PetType.builder().id(id).build();
+
+        final var savedPet = petTypeMapService.save(petType2);
+
+        assertEquals(id, savedPet.getId());
+        assertEquals(1, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void saveNoId() {
+
+        final var savedPet = petTypeMapService.save(PetType.builder().build());
+
+        assertNotNull(savedPet);
+        assertNotNull(savedPet.getId());
+        assertEquals(2, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void deletePetType() {
+
+        petTypeMapService.delete(petTypeMapService.findById(PET_TYPE_ID));
+
+        assertEquals(0, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithWrongId() {
+
+        final var petType = PetType.builder().id(5L).build();
+
+        petTypeMapService.delete(petType);
+
+        assertEquals(1, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithNullId() {
+
+        final var petType = PetType.builder().build();
+
+        petTypeMapService.delete(petType);
+
+        assertEquals(1, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void deleteNull() {
+
+        petTypeMapService.delete(null);
+
+        assertEquals(1, petTypeMapService.findAll().size());
+
+    }
+
+    @Test
+    void deleteByIdCorrectId() {
+
+        petTypeMapService.deleteById(PET_TYPE_ID);
+
+        assertEquals(0, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdWrongId() {
+
+        petTypeMapService.deleteById(5L);
+
+        assertEquals(1, petTypeMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdNullId() {
+
+        petTypeMapService.deleteById(null);
+
+        assertEquals(1, petTypeMapService.findAll().size());
+    }
+}

--- a/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/SpecialityMapServiceTest.java
+++ b/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/SpecialityMapServiceTest.java
@@ -1,0 +1,145 @@
+package guru.springframework.sfgpetclinic.services.map;
+
+import guru.springframework.sfgpetclinic.model.Speciality;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author <a href="https://www.github.com/yonatankarp>Yonatan Karp-Rudin</a>
+ */
+class SpecialityMapServiceTest {
+
+    private static final Long SPECIALTY_ID = 1L;
+
+    private SpecialityMapService specialityMapService;
+
+    @BeforeEach
+    void setUp() {
+        specialityMapService = new SpecialityMapService();
+
+        specialityMapService.save(Speciality.builder().id(SPECIALTY_ID).build());
+    }
+
+    @Test
+    void findAll() {
+        final var specialities = specialityMapService.findAll();
+        assertEquals(1, specialities.size());
+    }
+
+    @Test
+    void findByExistingId() {
+        final var speciality = specialityMapService.findById(SPECIALTY_ID);
+        assertEquals(SPECIALTY_ID, speciality.getId());
+    }
+
+    @Test
+    void findByNotExistingId() {
+        final var speciality = specialityMapService.findById(5L);
+        assertNull(speciality);
+    }
+
+    @Test
+    void findByIdNullId() {
+        final var speciality = specialityMapService.findById(null);
+        assertNull(speciality);
+    }
+
+    @Test
+    void saveExistingId() {
+        final Long id = 2L;
+
+        final var speciality2 = Speciality.builder().id(id).build();
+
+        final var savedSpecialty = specialityMapService.save(speciality2);
+
+        assertEquals(id, savedSpecialty.getId());
+    }
+
+    @Test
+    void saveDuplicateId() {
+
+        final Long id = 1L;
+
+        final var speciality2 = Speciality.builder().id(id).build();
+
+        final var savedSpeciality = specialityMapService.save(speciality2);
+
+        assertEquals(id, savedSpeciality.getId());
+        assertEquals(1, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void saveNoId() {
+
+        final var savedSpeciality = specialityMapService.save(Speciality.builder().build());
+
+        assertNotNull(savedSpeciality);
+        assertNotNull(savedSpeciality.getId());
+        assertEquals(2, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void deletePetType() {
+
+        specialityMapService.delete(specialityMapService.findById(SPECIALTY_ID));
+
+        assertEquals(0, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithWrongId() {
+
+        final var speciality = Speciality.builder().id(5L).build();
+
+        specialityMapService.delete(speciality);
+
+        assertEquals(1, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithNullId() {
+
+        final var speciality = Speciality.builder().build();
+
+        specialityMapService.delete(speciality);
+
+        assertEquals(1, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void deleteNull() {
+
+        specialityMapService.delete(null);
+
+        assertEquals(1, specialityMapService.findAll().size());
+
+    }
+
+    @Test
+    void deleteByIdCorrectId() {
+
+        specialityMapService.deleteById(SPECIALTY_ID);
+
+        assertEquals(0, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdWrongId() {
+
+        specialityMapService.deleteById(5L);
+
+        assertEquals(1, specialityMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdNullId() {
+
+        specialityMapService.deleteById(null);
+
+        assertEquals(1, specialityMapService.findAll().size());
+    }
+}

--- a/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/VetMapServiceTest.java
+++ b/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/VetMapServiceTest.java
@@ -1,0 +1,145 @@
+package guru.springframework.sfgpetclinic.services.map;
+
+import guru.springframework.sfgpetclinic.model.Vet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author <a href="https://www.github.com/yonatankarp>Yonatan Karp-Rudin</a>
+ */
+class VetMapServiceTest {
+
+    private static final Long VET_ID = 1L;
+
+    private VetMapService vetMapService;
+
+    @BeforeEach
+    void setUp() {
+        vetMapService = new VetMapService(new SpecialityMapService());
+
+        vetMapService.save(Vet.builder().id(VET_ID).build());
+    }
+
+    @Test
+    void findAll() {
+        final var vets = vetMapService.findAll();
+        assertEquals(1, vets.size());
+    }
+
+    @Test
+    void findByExistingId() {
+        final var vet = vetMapService.findById(VET_ID);
+        assertEquals(VET_ID, vet.getId());
+    }
+
+    @Test
+    void findByNotExistingId() {
+        final var vet = vetMapService.findById(5L);
+        assertNull(vet);
+    }
+
+    @Test
+    void findByIdNullId() {
+        final var vet = vetMapService.findById(null);
+        assertNull(vet);
+    }
+
+    @Test
+    void saveExistingId() {
+        final Long id = 2L;
+
+        final var vet2 = Vet.builder().id(id).build();
+
+        final var savedVet = vetMapService.save(vet2);
+
+        assertEquals(id, savedVet.getId());
+    }
+
+    @Test
+    void saveDuplicateId() {
+
+        final Long id = 1L;
+
+        final var vet2 = Vet.builder().id(id).build();
+
+        final var savedVet = vetMapService.save(vet2);
+
+        assertEquals(id, savedVet.getId());
+        assertEquals(1, vetMapService.findAll().size());
+    }
+
+    @Test
+    void saveNoId() {
+
+        final var savedVet = vetMapService.save(Vet.builder().build());
+
+        assertNotNull(savedVet);
+        assertNotNull(savedVet.getId());
+        assertEquals(2, vetMapService.findAll().size());
+    }
+
+    @Test
+    void deletePetType() {
+
+        vetMapService.delete(vetMapService.findById(VET_ID));
+
+        assertEquals(0, vetMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithWrongId() {
+
+        final var vet = Vet.builder().id(5L).build();
+
+        vetMapService.delete(vet);
+
+        assertEquals(1, vetMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithNullId() {
+
+        final var vet = Vet.builder().build();
+
+        vetMapService.delete(vet);
+
+        assertEquals(1, vetMapService.findAll().size());
+    }
+
+    @Test
+    void deleteNull() {
+
+        vetMapService.delete(null);
+
+        assertEquals(1, vetMapService.findAll().size());
+
+    }
+
+    @Test
+    void deleteByIdCorrectId() {
+
+        vetMapService.deleteById(VET_ID);
+
+        assertEquals(0, vetMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdWrongId() {
+
+        vetMapService.deleteById(5L);
+
+        assertEquals(1, vetMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdNullId() {
+
+        vetMapService.deleteById(null);
+
+        assertEquals(1, vetMapService.findAll().size());
+    }
+}

--- a/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/VisitMapServiceTest.java
+++ b/pet-clinic-data/src/test/java/guru/springframework/sfgpetclinic/services/map/VisitMapServiceTest.java
@@ -1,0 +1,165 @@
+package guru.springframework.sfgpetclinic.services.map;
+
+import guru.springframework.sfgpetclinic.model.Owner;
+import guru.springframework.sfgpetclinic.model.Pet;
+import guru.springframework.sfgpetclinic.model.Visit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author <a href="https://www.github.com/yonatankarp>Yonatan Karp-Rudin</a>
+ */
+class VisitMapServiceTest {
+
+    private static final Long VISIT_ID = 1L;
+    private static final Long PET_ID = 10L;
+    private static final Long OWNER_ID = 100L;
+
+    private VisitMapService visitMapService;
+
+    @BeforeEach
+    void setUp() {
+        visitMapService = new VisitMapService();
+
+
+        final var visit = connectVisitToPetAndOwner(Visit.builder().id(VISIT_ID).build(), OWNER_ID, PET_ID);
+        visitMapService.save(visit);
+    }
+
+    @Test
+    void findAll() {
+        final var visits = visitMapService.findAll();
+        assertEquals(1, visits.size());
+    }
+
+    @Test
+    void findByExistingId() {
+        final var visits = visitMapService.findById(VISIT_ID);
+        assertEquals(VISIT_ID, visits.getId());
+    }
+
+    @Test
+    void findByNotExistingId() {
+        final var visit = visitMapService.findById(5L);
+        assertNull(visit);
+    }
+
+    @Test
+    void findByIdNullId() {
+        final var visit = visitMapService.findById(null);
+        assertNull(visit);
+    }
+
+    @Test
+    void saveExistingId() {
+        final Long id = 2L;
+
+        final var visit2 = connectVisitToPetAndOwner(Visit.builder().id(id).build(), OWNER_ID, PET_ID);
+
+        final var savedVisit = visitMapService.save(visit2);
+
+        assertEquals(id, savedVisit.getId());
+    }
+
+    @Test
+    void saveDuplicateId() {
+
+        final Long id = 1L;
+
+        final var visit2 = connectVisitToPetAndOwner(Visit.builder().id(id).build(), OWNER_ID, PET_ID);
+
+        final var savedVisit = visitMapService.save(visit2);
+
+        assertEquals(id, savedVisit.getId());
+        assertEquals(1, visitMapService.findAll().size());
+    }
+
+    @Test
+    void saveNoId() {
+
+        final var visit = connectVisitToPetAndOwner(Visit.builder().build(), OWNER_ID, PET_ID);
+
+        final var savedVisit = visitMapService.save(visit);
+
+        assertNotNull(savedVisit);
+        assertNotNull(savedVisit.getId());
+        assertEquals(2, visitMapService.findAll().size());
+    }
+
+    @Test
+    void deletePetType() {
+
+        visitMapService.delete(visitMapService.findById(VISIT_ID));
+
+        assertEquals(0, visitMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithWrongId() {
+
+        final var visit = Visit.builder().id(5L).build();
+
+        visitMapService.delete(visit);
+
+        assertEquals(1, visitMapService.findAll().size());
+    }
+
+    @Test
+    void deleteWithNullId() {
+
+        final var visit = Visit.builder().build();
+
+        visitMapService.delete(visit);
+
+        assertEquals(1, visitMapService.findAll().size());
+    }
+
+    @Test
+    void deleteNull() {
+
+        visitMapService.delete(null);
+
+        assertEquals(1, visitMapService.findAll().size());
+
+    }
+
+    @Test
+    void deleteByIdCorrectId() {
+
+        visitMapService.deleteById(VISIT_ID);
+
+        assertEquals(0, visitMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdWrongId() {
+
+        visitMapService.deleteById(5L);
+
+        assertEquals(1, visitMapService.findAll().size());
+    }
+
+    @Test
+    void deleteByIdNullId() {
+
+        visitMapService.deleteById(null);
+
+        assertEquals(1, visitMapService.findAll().size());
+    }
+
+    private Visit connectVisitToPetAndOwner(final Visit visit, final Long ownerId, final Long petId) {
+        final var pet = Pet.builder().id(ownerId).build();
+        final var owner = Owner.builder().id(petId).build();
+
+        pet.setOwner(owner);
+        owner.getPets().add(pet);
+
+        visit.setPet(pet);
+
+        return visit;
+    }
+}


### PR DESCRIPTION
This PR adds all the missing unit tests for the Map services alongside the following changes:

- Make all models have fully working `builder`.
- Utilize Java11 `var` language syntax.
- Add `final` to all variables (as it's very common in the industry)
- Add missing tests for `OwnerMapService`.
- Suppress Jpa column warning on all models.

This could have been split into multiple PRs, but since all things are connected and many of the changes are minors I don't see it as a bit issue.